### PR TITLE
remove type field from artifact resource

### DIFF
--- a/src/_artifacts.tf
+++ b/src/_artifacts.tf
@@ -46,7 +46,6 @@ locals {
 resource "massdriver_artifact" "mongo_authentication" {
   field                = "mongo_authentication"
   provider_resource_id = "${var.namespace}/${local.mongo_host}"
-  type                 = "mongo-authentication"
   name                 = "Mongo at ${var.namespace}/${local.mongo_host}"
   artifact             = jsonencode(local.artifact_mongo_authentication)
 }


### PR DESCRIPTION
This is causing an issue in prod. After merging I'll want to cut a release.

```
Argument is deprecated
This field is being removed and instead the type is fetched from the massdriver.yaml file
Argument is deprecated
This field is being removed and instead the type is fetched from the massdriver.yaml file
```