### PR TITLE
bump chart version

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,12 +1,12 @@
 locals {
-  chart_version = "11.0.6"
+  chart_version = "13.16.2"
   # The chart doesn't have a "mongo version" field, this is a local used in
   # the artifact so we can expose the mongo version being used
   # It looks like we could override the docker image for various
   # parts of mongo. The arbiter, the mongod instances, etc..
   # I assume 3.latest would work but didn't go down the path of swapping out
   # various components to support another major version
-  mongo_db_version = "4.4.13"
+  mongo_db_version = "6.0.8"
   release          = var.md_metadata.name_prefix
 }
 


### PR DESCRIPTION
We don't expose the "version" here as a parameter, which we probably eventually should do, but all of the bitnami charts will be a bit volatile now since they are deprecating older versions fairly quickly.